### PR TITLE
Fix typo on index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -75,7 +75,7 @@ flex/bison to simplify parser generation.</p>
 <pre><code>./cremacc -f &lt;path-to-a-crema-file&gt; -o program
 </code></pre>
 
-<p>To print LLVM assembly to a fi(C) 2014-2015 Assured Information Security, Inc.le, use the -S option:
+<p>To print LLVM assembly to a file, use the -S option:
 <code>./cremacc -f &lt;path-to-a-crema-file&gt; -S &lt;output-file-name&gt;.ll</code></p>
 
 <p>For help with all of the other command line options available for cremacc, simply run:


### PR DESCRIPTION
It was probably a bad copy/paste job.
